### PR TITLE
Removing extra spaces makes things work in 2.4

### DIFF
--- a/block_gsb.php
+++ b/block_gsb.php
@@ -896,4 +896,3 @@ class block_gsb extends block_base {
 		}
 	}
 }
-?>  


### PR DESCRIPTION
Fix for #1, from here: 

https://tracker.moodle.org/browse/MDL-37649?focusedCommentId=199401&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-199401

Posted the issue in the Moodle Tracker as one of the core devs asked me to (because of the 'error produces no error' issue) and this solution came up. This pull request literally removes the spaces.
